### PR TITLE
fix: Darwin compilation of System/Posix/Timer.idr

### DIFF
--- a/posix/codegen/timer.c
+++ b/posix/codegen/timer.c
@@ -37,9 +37,13 @@ int main() {
   printf("itimerval_size : Bits32\n");
   printf("itimerval_size = %zd\n", sizeof(struct itimerval));
 
-#ifndef __APPLE__
   printf("\npublic export %%inline\n");
   printf("itimerspec_size : Bits32\n");
+#ifdef __APPLE__
+  // This isn't intended to be functional on darwin, just support compilation
+  // of the Idris counterpart.
+  printf("itimerspec_size = 0\n");
+#else
   printf("itimerspec_size = %zd\n", sizeof(struct itimerspec));
 #endif
 


### PR DESCRIPTION
Small tweak on the solution you had for compiling the codegen C code on Darwin. With the definition of `itimerspec_size` entirely omitted, Idris compilation failed:
```
Error: While processing right hand side of sizeof_. Undefined name itimerspec_size.

System.Posix.Timer:162:13--162:28
 158 |   unwrap = ptr
 159 |
 160 | export %inline
 161 | SizeOf Itimerspec where
 162 |   sizeof_ = itimerspec_size
                   ^^^^^^^^^^^^^^^
Did you mean any of: timespec_size, itimerval_size, or TimespecSize?
```

Since you weren't concerned about the `Itimerspec` type being usable on Darwin regardless, giving `itimerspec_size` a marker value of `0` seems about as good while supporting Idris compilation of the code.