### PR TITLE
Perform a full posix lib build on Darwin architecture

### DIFF
--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -1,0 +1,42 @@
+---
+name: Darwin Posix Build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+    working-directory: posix
+
+jobs:
+  darwin-build:
+    name: Build Posix lib for Darwin
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          extra_nix_config: |
+            extra-trusted-public-keys = gh-nix-idris2-packages.cachix.org-1:iOqSB5DrESFT+3A1iNzErgB68IDG8BrHLbLkhztOXfo=
+            extra-substituters = https://gh-nix-idris2-packages.cachix.org
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build lib
+        run: |
+          nix-build --expr '
+            let buildIdris = ((import (builtins.fetchGit { url = "https://github.com/mattpolzin/nix-idris2-packages.git"; ref = "main"; })) {}).buildIdris'\'';
+            in buildIdris { src = ./.; ipkgName = "posix"; }
+          '
+      - name: Inspect build
+        run: nix run nixpkgs#tree -- ./result


### PR DESCRIPTION
I don't expect you'll want to merge this and you can close it at your leisure if that's the case, but I wanted to go through the exercise of figuring out _how_ to do this myself at which point I figured I would share the results in case they were even mildly interesting.

So all this is actually doing is building the Posix library for Darwin but, unlike with the existing workflow that just builds the C library, this workflow builds the whole Idris2 library start to finish directly on Darwin as can be seen in the inspect step output (a `dylib` shared library is produced).