### PR TITLE
macOS 13 fix

### DIFF
--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -19,9 +19,13 @@ defaults:
 jobs:
   darwin-build:
     name: Build Posix lib for Darwin
-    runs-on: macos-latest
     strategy:
       fail-fast: false
+      matrix:
+        os:
+          - macos-13
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix
         uses: cachix/install-nix-action@v24

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -12,6 +12,8 @@ on:
       - main
       - master
 
+permissions: {}
+
 jobs:
   build:
     name: Lint Code Base
@@ -19,13 +21,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v6
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CLANG_FORMAT: false

--- a/.github/workflows/ci-support-c.yml
+++ b/.github/workflows/ci-support-c.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 defaults:
   run:
     shell: bash

--- a/posix/codegen/socket.c
+++ b/posix/codegen/socket.c
@@ -43,7 +43,10 @@ int main() {
   print_flag("MSG_OOB", MSG_OOB);
   print_flag("MSG_PEEK", MSG_PEEK);
   print_flag("MSG_WAITALL", MSG_WAITALL);
+#ifdef MSG_NOSIGNAL
+  // known to be undefined for older versions of macOS
   print_flag("MSG_NOSIGNAL", MSG_NOSIGNAL);
+#endif
 
   printf("\npublic export\n");
   printf("sockaddr_un_size : Bits32\n");


### PR DESCRIPTION
This fixes compilation for macOS 13 and enables CI for that version of macOS -- this not only tests an older version of macOS but also covers the intel architecture (macOS latest in CI runs on arm architecture).