### PR TITLE
epoll_pwait2 and pthread_sigqueue for Musl libc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ charset = utf-8
 # Idris source files
 [*.{idr,ipkg,tex,yaff,lidr}]
 indent_style = space
-indent_size = 2
+#indent_size = 2
 
 # Various configuration files
 [{*.yml,.ecrc}]
@@ -24,7 +24,7 @@ indent_size = 4
 
 [*.{c,h}]
 indent_style = space
-indent_size = 4
+#indent_size = 4
 
 [*.{md,rst}]
 indent_style = space
@@ -32,7 +32,7 @@ indent_size = 2
 
 [*.sh]
 indent_style = space
-indent_size = 4
+indent_size = 2
 shell_variant = posix
 switch_case_indent = true
 

--- a/linux/support/CPPLINT.cfg
+++ b/linux/support/CPPLINT.cfg
@@ -1,0 +1,2 @@
+filter=-readability/casting
+filter=-runtime/printf

--- a/linux/support/CPPLINT.cfg
+++ b/linux/support/CPPLINT.cfg
@@ -1,2 +1,1 @@
 filter=-readability/casting
-filter=-runtime/printf

--- a/linux/support/linux.c
+++ b/linux/support/linux.c
@@ -19,6 +19,9 @@
 #include <sys/statvfs.h>
 #include <sys/timerfd.h>
 #include <unistd.h>
+#if !defined(__GLIBC__)
+#include <limits.h>
+#endif
 
 #define CHECKRES                                                               \
   if (res == -1) {                                                             \
@@ -84,6 +87,34 @@ int li_epoll_wait(int epfd, struct epoll_event *evlist, int max, int timeout) {
   int res = epoll_wait(epfd, evlist, max, timeout);
   CHECKRES
 }
+
+#if !defined(__GLIBC__)
+// Implementation in terms of epoll_pwait for Musl libc
+int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
+                 const struct timespec *timeout, const sigset_t *sigmask)
+{
+  int timeout_ms;
+
+  if (timeout == NULL) {
+    timeout_ms = -1;  // Infinite timeout
+  } else {
+    // Convert timespec to milliseconds
+    long long ms =
+      (long long)timeout->tv_sec*1000LL + timeout->tv_nsec/1000000LL;
+
+    if (ms > INT_MAX) {
+      timeout_ms = INT_MAX;
+    } else if (ms < 0) {
+      errno = EINVAL;
+      return -1;
+    } else {
+      timeout_ms = (int)ms;
+    }
+  }
+
+  return epoll_pwait(epfd, events, maxevents, timeout_ms, sigmask);
+}
+#endif
 
 int li_epoll_pwait2(int epfd, struct epoll_event *evlist, int max,
                     const struct timespec *timeout) {
@@ -222,6 +253,15 @@ int li_pipe2(int fs[2], uint32_t flags) {
 ////////////////////////////////////////////////////////////////////////////////
 // pthreads
 ////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(__GLIBC__)
+// stub implemetation for Musl libc
+int pthread_sigqueue(pthread_t thread, int sig, const union sigval value)
+{
+  // We can't pass the sigval, so we return EINVAL to indicate failure
+  return EINVAL;
+}
+#endif
 
 uint32_t li_pthread_sigqueue(pthread_t p, int sig, int word) {
   union sigval u = {.sival_int = word};

--- a/linux/support/linux.c
+++ b/linux/support/linux.c
@@ -91,8 +91,7 @@ int li_epoll_wait(int epfd, struct epoll_event *evlist, int max, int timeout) {
 #if !defined(__GLIBC__)
 // Implementation in terms of epoll_pwait for Musl libc
 int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
-                 const struct timespec *timeout, const sigset_t *sigmask)
-{
+                 const struct timespec *timeout, const sigset_t *sigmask) {
   int timeout_ms;
 
   if (timeout == NULL) {
@@ -256,8 +255,7 @@ int li_pipe2(int fs[2], uint32_t flags) {
 
 #if !defined(__GLIBC__)
 // stub implemetation for Musl libc
-int pthread_sigqueue(pthread_t thread, int sig, const union sigval value)
-{
+int pthread_sigqueue(pthread_t thread, int sig, const union sigval value) {
   // We can't pass the sigval, so we return EINVAL to indicate failure
   return EINVAL;
 }

--- a/linux/support/linux.c
+++ b/linux/support/linux.c
@@ -98,8 +98,8 @@ int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
     timeout_ms = -1;  // Infinite timeout
   } else {
     // Convert timespec to milliseconds
-    long long ms =
-      (long long)timeout->tv_sec*1000LL + timeout->tv_nsec/1000000LL;
+    int64_t ms =
+      (int64_t)timeout->tv_sec*1000LL + timeout->tv_nsec/1000000LL;
 
     if (ms > INT_MAX) {
       timeout_ms = INT_MAX;


### PR DESCRIPTION
This adds an implementation of `epoll_pwait2` in terms of `epoll_pwait` and a stub implementation of `pthread_sigqueue` for Musl libc which lacks both of these.

I'm not quite sure how best to test this, but I can confirm that an application which uses `epoll_pwait2` via idris2-async builds and runs successfully in an Alpine container.

Fixes #96 