### PR TITLE
Switch to supported MacOS intel runner for CI

### DIFF
--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -4,9 +4,9 @@ name: Darwin Posix Build
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
-      - '**'
+      - "**"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v24
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             extra-trusted-public-keys = gh-nix-idris2-packages.cachix.org-1:iOqSB5DrESFT+3A1iNzErgB68IDG8BrHLbLkhztOXfo=

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v6
+        uses: super-linter/super-linter/slim@v8
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CLANG_FORMAT: false

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -4,9 +4,9 @@ name: Lint
 on:
   push:
     branches:
-      - '*'
+      - "*"
     tags:
-      - '*'
+      - "*"
   pull_request:
     branches:
       - main
@@ -19,7 +19,6 @@ jobs:
     name: Lint Code Base
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -30,7 +30,9 @@ jobs:
         uses: super-linter/super-linter/slim@v8
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BIOME_FORMAT: false
           VALIDATE_CLANG_FORMAT: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GENERATED_FILES: true


### PR DESCRIPTION
The macos-13 runner is not longer supported, now intel macos CI is done via a specially tagged macos-15 runner.