### PR TITLE
Add named FromBuf implementaions for numeric strings

### DIFF
--- a/posix/src/System/Posix/File/ReadRes.idr
+++ b/posix/src/System/Posix/File/ReadRes.idr
@@ -161,6 +161,42 @@ FromBuf String where
     let (n ** ib) # t := fromBuf {a = EBuffer} buf t
      in toString ib 0 n # t
 
+export %inline
+[DecimalString] FromBuf (Maybe Nat) where
+  fromBuf b t =
+    let bs # t := fromBuf {a=ByteString} b t
+    in (parseDecimalNat bs) # t
+
+export %inline
+[HexadecimalString] FromBuf (Maybe Nat) where
+  fromBuf b t =
+    let bs # t := fromBuf {a=ByteString} b t
+    in (parseHexadecimalNat bs) # t
+
+export %inline
+[OctalString] FromBuf (Maybe Nat) where
+  fromBuf b t =
+    let bs # t := fromBuf {a=ByteString} b t
+    in (parseOctalNat bs) # t
+
+export %inline
+[BinaryString] FromBuf (Maybe Nat) where
+  fromBuf b t =
+    let bs # t := fromBuf {a=ByteString} b t
+    in (parseBinaryNat bs) # t
+
+export %inline
+[IntegerString] FromBuf (Maybe Integer) where
+  fromBuf b t =
+    let bs # t := fromBuf {a=ByteString} b t
+    in (parseInteger bs) # t
+
+export %inline
+[DoubleString] FromBuf (Maybe Double) where
+  fromBuf b t =
+    let bs # t := fromBuf {a=ByteString} b t
+    in (parseDouble bs) # t
+
 public export
 0 ECArrayIO : Type -> Type
 ECArrayIO t = (n ** CArrayIO n t)


### PR DESCRIPTION
I've named these implementations since they probably don't make sense as the *default* way to get a numeric out of a buffer, but it certainly seems useful to have.