### PR TITLE
Added getpeername/getsockname

### DIFF
--- a/posix/src/System/Posix/Socket.idr
+++ b/posix/src/System/Posix/Socket.idr
@@ -108,3 +108,24 @@ parameters {auto has : Has Errno es}
     -> Sockaddr d
     -> f es Bits32
   sendto s r f a = elift1 $ P.sendto s r f a
+
+  ||| Returns the address of the peer connected to a socket.
+  ||| The given Sockaddr buffer will be filled with the peer address.
+  export %inline
+  getpeername_ : {d : _} -> Socket d -> Sockaddr d -> f es ()
+  getpeername_ s a = elift1 $ P.getpeername_ s a
+
+  ||| Returns the current address to which the socket is bound.
+  ||| The given Sockaddr buffer will be filled with the socket's address.
+  export %inline
+  getsockname_ : {d : _} -> Socket d -> Sockaddr d -> f es ()
+  getsockname_ s a = elift1 $ P.getsockname_ s a
+
+  ||| Returns the address of the peer connected to a socket.
+  export %inline
+  getpeername : {d : _} -> Socket d -> f es (Addr d)
+  getpeername s = elift1 $ P.getpeername s
+
+  export %inline
+  getsockname : {d : _} -> Socket d -> f es (Addr d)
+  getsockname s = elift1 $ P.getsockname s

--- a/posix/src/System/Posix/Socket/Prim.idr
+++ b/posix/src/System/Posix/Socket/Prim.idr
@@ -52,6 +52,12 @@ prim__sendto : (file : Bits32) -> Buffer -> (off,max : Bits32) -> Bits32 -> AnyP
 %foreign "C__collect_safe:li_sendto, posix-idris"
 prim__sendtoptr : (file : Bits32) -> AnyPtr -> (off,max : Bits32) -> Bits32 -> AnyPtr -> Bits32 -> PrimIO SsizeT
 
+%foreign "C:li_getpeername, posix-idris"
+prim__getpeername : Bits32 -> AnyPtr -> Bits32 -> PrimIO CInt
+
+%foreign "C:li_getsockname, posix-idris"
+prim__getsockname : Bits32 -> AnyPtr -> Bits32 -> PrimIO CInt
+
 --------------------------------------------------------------------------------
 -- API
 --------------------------------------------------------------------------------
@@ -170,3 +176,47 @@ connect : {d : _} -> Socket d -> Addr d -> EPrim ()
 connect s a t =
   let addr # t := sockaddr d a t
    in finally (prim__free $ ptr d addr) (connect_ s addr) t
+
+||| Returns the address of the peer connected to a socket.
+||| The given Sockaddr buffer will be filled with the peer address.
+export
+getpeername_ : {d : _} -> Socket d -> Sockaddr d -> EPrim ()
+getpeername_ s a = toUnit $ prim__getpeername (fileDesc s) (ptr d a) (addrSize d)
+
+||| Returns the current address to which the socket is bound.
+||| The given Sockaddr buffer will be filled with the socket's address.
+export
+getsockname_ : {d : _} -> Socket d -> Sockaddr d -> EPrim ()
+getsockname_ s a = toUnit $ prim__getsockname (fileDesc s) (ptr d a) (addrSize d)
+
+||| Returns the address of the peer connected to a socket.
+export
+getpeername : {d : _} -> Socket d -> EPrim (Addr d)
+getpeername {d = AF_UNIX} s = withStruct SSockaddrUn $ \a,t =>
+  let R _ t := getpeername_ s a t | E x t => E x t
+      p # t := path a t
+    in R p t
+getpeername {d = AF_INET} s = withStruct SSockaddrIn $ \a,t =>
+  let R _   t := getpeername_ s a t | E x t => E x t
+      ipp # t := SockaddrIn.addrIP4Addr a t
+    in R ipp t
+getpeername {d = AF_INET6} s = withStruct SSockaddrIn6 $ \a,t =>
+  let R _  t := getpeername_ s a t | E x t => E x t
+      ipp # t := SockaddrIn6.addrIP6Addr a t
+    in R ipp t
+
+||| Returns the current address to which the socket is bound.
+export
+getsockname : {d : _} -> Socket d -> EPrim (Addr d)
+getsockname {d = AF_UNIX} s = withStruct SSockaddrUn $ \a,t =>
+  let R _ t := getsockname_ s a t | E x t => E x t
+      p # t := path a t
+    in R p t
+getsockname {d = AF_INET} s = withStruct SSockaddrIn $ \a,t =>
+  let R _   t := getsockname_ s a t | E x t => E x t
+      ipp # t := SockaddrIn.addrIP4Addr a t
+    in R ipp t
+getsockname {d = AF_INET6} s = withStruct SSockaddrIn6 $ \a,t =>
+  let R _  t := getsockname_ s a t | E x t => E x t
+      ipp # t := SockaddrIn6.addrIP6Addr a t
+    in R ipp t

--- a/posix/src/System/Posix/Socket/Struct.idr
+++ b/posix/src/System/Posix/Socket/Struct.idr
@@ -128,6 +128,13 @@ namespace SockaddrIn
   addr : SSockaddrIn s -> F1 s Bits32
   addr (SIN p) = ffi $ prim__sockaddr_in_addr p
 
+  export
+  addrIP4Addr : SSockaddrIn s -> F1 s IP4Addr
+  addrIP4Addr a t =
+    let p  # t := SockaddrIn.port a t
+        ad # t := SockaddrIn.addr a t
+     in IP4 (splitIp4Addr ad) p # t
+
   export %inline
   addrStr : SSockaddrIn s -> F1 s String
   addrStr (SIN p) = ffi $ prim__sockaddr_in_addr_str p
@@ -189,6 +196,14 @@ namespace SockaddrIn6
   export %inline
   addr6 : SSockaddrIn6 s -> CArray s 16 Bits8
   addr6 (SIN6 p) = unsafeWrap (prim__sockaddr_in6_addr p)
+
+  export
+  addrIP6Addr : SSockaddrIn6 s -> F1 s IP6Addr
+  addrIP6Addr a t =
+    let p  # t  := SockaddrIn6.port a t
+        bs # t  := values [] (addr6 a) (#) 16 t
+        Just ad := toVect 16 bs | Nothing => IP6 (replicate 16 0) p # t
+     in IP6 ad p # t
 
   export %inline
   addrStr : SSockaddrIn6 s -> F1 s String

--- a/posix/support/posix.c
+++ b/posix/support/posix.c
@@ -805,6 +805,18 @@ ssize_t li_sendto(int fd, char *buf, size_t off, size_t bytes, int flags,
   CHECKRES
 }
 
+int li_getpeername(int sfd, struct sockaddr *addr, socklen_t len) {
+  socklen_t plen = len;
+  int res = getpeername(sfd, addr, &plen);
+  CHECKRES
+}
+
+int li_getsockname(int sfd, struct sockaddr *addr, socklen_t len) {
+  socklen_t plen = len;
+  int res = getsockname(sfd, addr, &plen);
+  CHECKRES
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Time
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds implementations of `getpeername` and `getsockname`.

I think I've followed all the relevant conventions around the FFI. I'm not completely sure that the use of `Errono.values` to construct a `List` from a `CArray` is appropriate usage, but it seems to do the trick.