### PR TITLE
Added support for essential socket options for HTTP

### DIFF
--- a/posix/codegen/socket.c
+++ b/posix/codegen/socket.c
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 
 void print_domain(const char *name, int value) {
   printf("domainCode %s = %d\n", name, value);
@@ -21,6 +22,12 @@ void print_type(const char *name, int value) {
 void print_flag(const char *name, int value) {
   printf("\npublic export\n");
   printf("%s : SockFlags\n", name);
+  printf("%s = %d\n", name, value);
+}
+
+void print_sockopt(const char *name, int value) {
+  printf("\npublic export\n");
+  printf("%s : Bits32\n", name);
   printf("%s = %d\n", name, value);
 }
 
@@ -59,6 +66,15 @@ int main() {
   printf("\npublic export\n");
   printf("sockaddr_in6_size : Bits32\n");
   printf("sockaddr_in6_size = %zd\n", sizeof(struct sockaddr_in6));
+
+  // Socket option levels
+  print_sockopt("SOL_SOCKET", SOL_SOCKET);
+  print_sockopt("IPPROTO_TCP", IPPROTO_TCP);
+
+  // Socket options
+  print_sockopt("SO_REUSEADDR", SO_REUSEADDR);
+  print_sockopt("SO_LINGER", SO_LINGER);
+  print_sockopt("TCP_NODELAY", TCP_NODELAY);
 
   exit(0);
 }

--- a/posix/src/System/Posix/Socket.idr
+++ b/posix/src/System/Posix/Socket.idr
@@ -129,3 +129,22 @@ parameters {auto has : Has Errno es}
   export %inline
   getsockname : {d : _} -> Socket d -> f es (Addr d)
   getsockname s = elift1 $ P.getsockname s
+
+  ||| Enables or disables the Nagle algorithm.
+  export %inline
+  setNoDelay : Socket d -> Bool -> f es ()
+  setNoDelay s b = elift1 $ P.setNoDelay s b
+
+  ||| Allows binding to an address/port before the expiry of the TIME_WAIT state.
+  export %inline
+  setReuseAddress : Socket d -> Bool -> f es ()
+  setReuseAddress s b = elift1 $ P.setReuseAddress s b
+
+  ||| Sets the linger option for a socket.
+  |||
+  ||| `Nothing` disables lingering (close returns immediately).
+  ||| `Just 0` enables a hard close (RST sent, data discarded).
+  ||| `Just n` for n > 0 waits up to n seconds for data to be sent before closing.
+  export %inline
+  setLinger : Socket d -> Maybe Bits32 -> f es ()
+  setLinger s t = elift1 $ P.setLinger s t

--- a/posix/src/System/Posix/Socket/Prim.idr
+++ b/posix/src/System/Posix/Socket/Prim.idr
@@ -58,6 +58,12 @@ prim__getpeername : Bits32 -> AnyPtr -> Bits32 -> PrimIO CInt
 %foreign "C:li_getsockname, posix-idris"
 prim__getsockname : Bits32 -> AnyPtr -> Bits32 -> PrimIO CInt
 
+%foreign "C:li_setsockopt_int, posix-idris"
+prim__setsockopt_int : Bits32 -> Bits32 -> Bits32 -> Bits32 -> PrimIO CInt
+
+%foreign "C:li_setsockopt_linger, posix-idris"
+prim__setsockopt_linger : Bits32 -> Bits32 -> Bits32 -> PrimIO CInt
+
 --------------------------------------------------------------------------------
 -- API
 --------------------------------------------------------------------------------
@@ -220,3 +226,31 @@ getsockname {d = AF_INET6} s = withStruct SSockaddrIn6 $ \a,t =>
   let R _  t := getsockname_ s a t | E x t => E x t
       ipp # t := SockaddrIn6.addrIP6Addr a t
     in R ipp t
+
+--------------------------------------------------------------------------------
+-- Socket Options
+--------------------------------------------------------------------------------
+
+boolToInt : Bool -> Bits32
+boolToInt False = 0
+boolToInt True  = 1
+
+||| Enables or disables the Nagle algorithm.
+export
+setNoDelay : Socket d -> Bool -> EPrim ()
+setNoDelay s b = toUnit $ prim__setsockopt_int (fileDesc s) IPPROTO_TCP TCP_NODELAY (boolToInt b)
+
+||| Allows binding to an address/port before the expiry of the TIME_WAIT state.
+export
+setReuseAddress : Socket d -> Bool -> EPrim ()
+setReuseAddress s b = toUnit $ prim__setsockopt_int (fileDesc s) SOL_SOCKET SO_REUSEADDR (boolToInt b)
+
+||| Sets the linger option for a socket.
+|||
+||| `Nothing` disables lingering (close returns immediately).
+||| `Just 0` enables a hard close (RST sent, data discarded).
+||| `Just n` for n > 0 waits up to n seconds for data to be sent before closing.
+export
+setLinger : Socket d -> Maybe Bits32 -> EPrim ()
+setLinger s Nothing  = toUnit $ prim__setsockopt_linger (fileDesc s) 0 0
+setLinger s (Just t) = toUnit $ prim__setsockopt_linger (fileDesc s) 1 t

--- a/posix/src/System/Posix/Socket/Prim.idr
+++ b/posix/src/System/Posix/Socket/Prim.idr
@@ -58,8 +58,8 @@ prim__getpeername : Bits32 -> AnyPtr -> Bits32 -> PrimIO CInt
 %foreign "C:li_getsockname, posix-idris"
 prim__getsockname : Bits32 -> AnyPtr -> Bits32 -> PrimIO CInt
 
-%foreign "C:li_setsockopt_int, posix-idris"
-prim__setsockopt_int : Bits32 -> Bits32 -> Bits32 -> Bits32 -> PrimIO CInt
+%foreign "C:li_setsockopt_bool, posix-idris"
+prim__setsockopt_bool : Bits32 -> Bits32 -> Bits32 -> Bits8 -> PrimIO CInt
 
 %foreign "C:li_setsockopt_linger, posix-idris"
 prim__setsockopt_linger : Bits32 -> Bits32 -> Bits32 -> PrimIO CInt
@@ -231,19 +231,19 @@ getsockname {d = AF_INET6} s = withStruct SSockaddrIn6 $ \a,t =>
 -- Socket Options
 --------------------------------------------------------------------------------
 
-boolToInt : Bool -> Bits32
+boolToInt : Bool -> Bits8
 boolToInt False = 0
 boolToInt True  = 1
 
 ||| Enables or disables the Nagle algorithm.
 export
 setNoDelay : Socket d -> Bool -> EPrim ()
-setNoDelay s b = toUnit $ prim__setsockopt_int (fileDesc s) IPPROTO_TCP TCP_NODELAY (boolToInt b)
+setNoDelay s b = toUnit $ prim__setsockopt_bool (fileDesc s) IPPROTO_TCP TCP_NODELAY (boolToInt b)
 
 ||| Allows binding to an address/port before the expiry of the TIME_WAIT state.
 export
 setReuseAddress : Socket d -> Bool -> EPrim ()
-setReuseAddress s b = toUnit $ prim__setsockopt_int (fileDesc s) SOL_SOCKET SO_REUSEADDR (boolToInt b)
+setReuseAddress s b = toUnit $ prim__setsockopt_bool (fileDesc s) SOL_SOCKET SO_REUSEADDR (boolToInt b)
 
 ||| Sets the linger option for a socket.
 |||

--- a/posix/src/System/Posix/Socket/Types.idr
+++ b/posix/src/System/Posix/Socket/Types.idr
@@ -104,3 +104,23 @@ sockaddr_in_size = 16
 public export
 sockaddr_in6_size : Bits32
 sockaddr_in6_size = 28
+
+public export
+SOL_SOCKET : Bits32
+SOL_SOCKET = 1
+
+public export
+IPPROTO_TCP : Bits32
+IPPROTO_TCP = 6
+
+public export
+SO_REUSEADDR : Bits32
+SO_REUSEADDR = 2
+
+public export
+SO_LINGER : Bits32
+SO_LINGER = 13
+
+public export
+TCP_NODELAY : Bits32
+TCP_NODELAY = 1

--- a/posix/support/posix.c
+++ b/posix/support/posix.c
@@ -817,6 +817,19 @@ int li_getsockname(int sfd, struct sockaddr *addr, socklen_t len) {
   CHECKRES
 }
 
+int li_setsockopt_int(int sfd, int level, int optname, int optval) {
+  int res = setsockopt(sfd, level, optname, &optval, sizeof(optval));
+  CHECKRES
+}
+
+int li_setsockopt_linger(int sfd, int onoff, int linger_time) {
+  struct linger lg;
+  lg.l_onoff = onoff;
+  lg.l_linger = linger_time;
+  int res = setsockopt(sfd, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg));
+  CHECKRES
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Time
 ////////////////////////////////////////////////////////////////////////////////

--- a/posix/support/posix.c
+++ b/posix/support/posix.c
@@ -817,7 +817,7 @@ int li_getsockname(int sfd, struct sockaddr *addr, socklen_t len) {
   CHECKRES
 }
 
-int li_setsockopt_int(int sfd, int level, int optname, int optval) {
+int li_setsockopt_bool(int sfd, int level, int optname, int optval) {
   int res = setsockopt(sfd, level, optname, &optval, sizeof(optval));
   CHECKRES
 }


### PR DESCRIPTION
This adds support for three essential socket options for implementing an HTTP server:
+ `SO_REUSEADDR` for the listening socket, which allows server restarts without waiting for `TIME_WAIT` to expire.
+ `TCP_NODELAY` for accepted sockets, which is important to reduce latency for small responses.
+ `SO_LINGER` for accepted sockets, which enables friendly clients to close connections first, reducing resource usage on the server.

I haven't attempted to put together a completely generic interface for `setsockopt`, only the convenience methods for the most common options which we might want to define in terms of such an interface. This doesn't close off the option of doing that later and using it to reimplement these functions.