### PR TITLE
stop running intel macos in CI

### DIFF
--- a/.github/workflows/ci-darwin-posix.yml
+++ b/.github/workflows/ci-darwin-posix.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-15-intel
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Nixpkgs has stopped supported Intel macos and since that is the underpinning for the CI jobs I set up to test against that architecture, these CI jobs are going to start failing anyway and may as well be removed.

Still in place are tests against the arm Macos architecture and there's still value in knowing things build on those newer mac systems.